### PR TITLE
feat: Add first HR account to database

### DIFF
--- a/service-auth/src/main/java/de/tum/devops/auth/AuthApplication.java
+++ b/service-auth/src/main/java/de/tum/devops/auth/AuthApplication.java
@@ -1,10 +1,16 @@
 package de.tum.devops.auth;
 
+import de.tum.devops.persistence.entity.User;
+import de.tum.devops.persistence.entity.UserRole;
+import de.tum.devops.persistence.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 /**
  * AI-HR Authentication Service
@@ -28,5 +34,26 @@ public class AuthApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(AuthApplication.class, args);
+    }
+
+    // create initial HR user if not exists
+    @Bean
+    public CommandLineRunner ensureAdminUser(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        Logger log = LoggerFactory.getLogger(AuthApplication.class);
+        return args -> {
+            // check if there is already an HR user
+            if (userRepository.countByRole(UserRole.HR) == 0) {
+                User admin = new User();
+                admin.setFullName("admin");
+                admin.setEmail("admin");
+                admin.setPasswordHash(passwordEncoder.encode("admin"));
+                admin.setRole(UserRole.HR);
+                userRepository.save(admin);
+                log.info("Created initial HR user: {}", admin.getEmail());
+            }
+            else {
+                log.info("HR user already exists, skipping creation.");
+            }
+        };
     }
 }


### PR DESCRIPTION
This pull request introduces functionality to ensure an initial HR user is created in the authentication service if one does not already exist. It also includes necessary imports and dependencies to support this feature.

Enhancements to user initialization:

* [`service-auth/src/main/java/de/tum/devops/auth/AuthApplication.java`](diffhunk://#diff-a02f588739302e3fb7b4e7dce078ed801c6dffbfc9cddb78729813c248fbeb68R38-R58): Added a `CommandLineRunner` bean to check for the existence of an HR user and create one with default credentials if none exists. This ensures the application starts with a predefined admin user.

Dependency additions:

* [`service-auth/src/main/java/de/tum/devops/auth/AuthApplication.java`](diffhunk://#diff-a02f588739302e3fb7b4e7dce078ed801c6dffbfc9cddb78729813c248fbeb68R3-R13): Imported `User`, `UserRole`, `UserRepository`, `PasswordEncoder`, and logging dependencies (`Logger` and `LoggerFactory`) to support the creation and logging of the initial HR user.