### PR TITLE
ci: deploy frontend

### DIFF
--- a/docker-compose.prod.deploy.yml
+++ b/docker-compose.prod.deploy.yml
@@ -18,8 +18,8 @@ services:
       - "--api.dashboard=true"
       - "--log.level=INFO"
     ports:
-      - "80:80"     # HTTP
-      - "443:443"   # HTTPS
+      - "80:80" # HTTP
+      - "443:443" # HTTPS
       - "8080:8080" # Traefik dashboard
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -46,10 +46,11 @@ services:
     networks:
       - ai-hr-network
     healthcheck:
-      test: [
-        "CMD-SHELL",
-        "PGPASSWORD=$$POSTGRES_PASSWORD psql -U $$POSTGRES_USER -d $$POSTGRES_DB -tAc \"SELECT to_regclass('public.embeddings');\" | grep -q embeddings"
-      ]
+      test:
+        [
+          "CMD-SHELL",
+          'PGPASSWORD=$$POSTGRES_PASSWORD psql -U $$POSTGRES_USER -d $$POSTGRES_DB -tAc "SELECT to_regclass(''public.embeddings'');" | grep -q embeddings',
+        ]
       interval: 20s
       timeout: 10s
       retries: 5
@@ -232,35 +233,22 @@ services:
       - DATABASE_URL=postgresql://${DB_USERNAME:-postgres}:${DB_PASSWORD:-postgres}@postgresql:5432/hrapp
       - ALLOW_ORIGINS=*
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8079/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8079/health"]
       interval: 30s
       timeout: 10s
       retries: 3
 
   # Frontend
-#  frontend:
-#    build:
-#      context: ./frontend
-#      dockerfile: Dockerfile
-#    container_name: ai-hr-frontend
-#    depends_on:
-#      service-auth:
-#        condition: service_healthy
-#      service-job:
-#        condition: service_healthy
-#      service-application:
-#        condition: service_healthy
-#      service-assess:
-#        condition: service_healthy
-#      service-genai:
-#        condition: service_healthy
-#    networks:
-#      - ai-hr-network
-#    labels:
-#      - "traefik.enable=true"
-#      - "traefik.http.routers.frontend.rule=Host(`localhost`)"
-#      - "traefik.http.routers.frontend.entrypoints=web"
-#      - "traefik.http.services.frontend.loadbalancer.server.port=80"
+  frontend:
+    image: ghcr.io/${GHCR_USER}/${GHCR_REPO}-frontend:${GHCR_TAG:-latest}
+    container_name: ai-hr-frontend
+    networks:
+      - ai-hr-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.frontend.rule=Host(`localhost`)"
+      - "traefik.http.routers.frontend.entrypoints=web"
+      - "traefik.http.services.frontend.loadbalancer.server.port=80"
 
 networks:
   ai-hr-network:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,8 +18,8 @@ services:
       - "--api.dashboard=true"
       - "--log.level=INFO"
     ports:
-      - "80:80"     # HTTP
-      - "443:443"   # HTTPS
+      - "80:80" # HTTP
+      - "443:443" # HTTPS
       - "8080:8080" # Traefik dashboard
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -49,10 +49,11 @@ services:
     networks:
       - ai-hr-network
     healthcheck:
-      test: [
-        "CMD-SHELL",
-        "PGPASSWORD=$$POSTGRES_PASSWORD psql -U $$POSTGRES_USER -d $$POSTGRES_DB -tAc \"SELECT to_regclass('public.embeddings');\" | grep -q embeddings"
-      ]
+      test:
+        [
+          "CMD-SHELL",
+          'PGPASSWORD=$$POSTGRES_PASSWORD psql -U $$POSTGRES_USER -d $$POSTGRES_DB -tAc "SELECT to_regclass(''public.embeddings'');" | grep -q embeddings',
+        ]
       interval: 20s
       timeout: 10s
       retries: 5
@@ -250,35 +251,25 @@ services:
       - DATABASE_URL=postgresql://${DB_USERNAME:-postgres}:${DB_PASSWORD:-postgres}@postgresql:5432/hrapp
       - ALLOW_ORIGINS=*
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8079/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8079/health"]
       interval: 30s
       timeout: 10s
       retries: 3
 
   # Frontend
-#  frontend:
-#    build:
-#      context: ./frontend
-#      dockerfile: Dockerfile
-#    container_name: ai-hr-frontend
-#    depends_on:
-#      service-auth:
-#        condition: service_healthy
-#      service-job:
-#        condition: service_healthy
-#      service-application:
-#        condition: service_healthy
-#      service-assess:
-#        condition: service_healthy
-#      service-genai:
-#        condition: service_healthy
-#    networks:
-#      - ai-hr-network
-#    labels:
-#      - "traefik.enable=true"
-#      - "traefik.http.routers.frontend.rule=Host(`localhost`)"
-#      - "traefik.http.routers.frontend.entrypoints=web"
-#      - "traefik.http.services.frontend.loadbalancer.server.port=80"
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    image: ghcr.io/${GHCR_USER}/${GHCR_REPO}-frontend:${GHCR_TAG:-latest}
+    container_name: ai-hr-frontend
+    networks:
+      - ai-hr-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.frontend.rule=Host(`localhost`)"
+      - "traefik.http.routers.frontend.entrypoints=web"
+      - "traefik.http.services.frontend.loadbalancer.server.port=80"
 
 networks:
   ai-hr-network:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build
 
 FROM nginx:1.27-alpine
 
-COPY --from=builder /app/build /usr/share/nginx/html
+COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80

--- a/helm/aihr/charts/frontend/Chart.yaml
+++ b/helm/aihr/charts/frontend/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: frontend
+description: AI HR frontend
+type: application
+version: 0.1.0

--- a/helm/aihr/charts/frontend/templates/_helpers.tpl
+++ b/helm/aihr/charts/frontend/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{/*
+Return fully-qualified name
+*/}}
+{{- define "frontend.fullname" -}}
+{{ include "aihr.releaseName" . }}-frontend
+{{- end }}

--- a/helm/aihr/charts/frontend/templates/deployment.yaml
+++ b/helm/aihr/charts/frontend/templates/deployment.yaml
@@ -1,0 +1,29 @@
+{{- $user := .Values.global.ghcrUser -}}
+{{- $repo := .Values.global.ghcrRepo -}}
+{{- $tag  := default "latest" .Values.global.imageTag -}}
+{{- $defRepo := printf "ghcr.io/%s/%s-frontend" $user $repo -}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "frontend.fullname" . }}
+  labels: { app: {{ include "frontend.fullname" . }} }
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels: { app: {{ include "frontend.fullname" . }} }
+  template:
+    metadata:
+      labels: { app: {{ include "frontend.fullname" . }} }
+    spec:
+      containers:
+        - name: frontend
+          image: "{{ default $defRepo .Values.image.repository }}:{{ default $tag .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+          readinessProbe:
+            httpGet: { path: /, port: http }
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/helm/aihr/charts/frontend/templates/ingress.yaml
+++ b/helm/aihr/charts/frontend/templates/ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.ingress.enabled }}
+{{- $host := .Values.ingress.host | default .Values.global.env.frontendHost | default .Values.global.env.host -}}
+{{- $tls  := .Values.ingress.tlsSecret | default .Values.global.env.tlsSecret -}}
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "frontend.fullname" . }}
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts: [ {{ $host | quote }} ]
+      secretName: {{ $tls }}
+  rules:
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: /          # 根路径
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "frontend.fullname" . }}
+                port:
+                  number: 80
+{{- end }}

--- a/helm/aihr/charts/frontend/templates/service.yaml
+++ b/helm/aihr/charts/frontend/templates/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: { { include "frontend.fullname" . } }
+  name: {{ include "frontend.fullname" . }}
 spec:
   selector:
-    app: { { include "frontend.fullname" . } }
+    app: {{ include "frontend.fullname" . }}
   ports:
     - port: 80
       targetPort: http

--- a/helm/aihr/charts/frontend/templates/service.yaml
+++ b/helm/aihr/charts/frontend/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: { { include "frontend.fullname" . } }
+spec:
+  selector:
+    app: { { include "frontend.fullname" . } }
+  ports:
+    - port: 80
+      targetPort: http
+      name: http

--- a/helm/aihr/charts/frontend/values.yaml
+++ b/helm/aihr/charts/frontend/values.yaml
@@ -1,0 +1,13 @@
+replicaCount: 1
+
+image:
+  repository: "" # default to let template fill ghcr.io/ghuser/ghrepo-frontend
+  tag: "" # follow global.imageTag
+  pullPolicy: IfNotPresent
+
+service:
+  port: 80
+
+ingress:
+  enabled: true
+  path: /

--- a/helm/aihr/values-dev.yaml
+++ b/helm/aihr/values-dev.yaml
@@ -4,3 +4,9 @@ global:
     host: api.ai-hr-dev.student.k8s.aet.cit.tum.de
     tlsSecret: ai-hr-dev-tls
     corsAllowed: "http://localhost:3000,http://localhost:5173,http://localhost:4200,https://ai-hr.student.k8s.aet.cit.tum.de/api/v1/applications"
+
+frontend:
+  ingress:
+    enabled: true
+    host: ai-hr-dev.student.k8s.aet.cit.tum.de
+    tlsSecret: ai-hr-dev-tls

--- a/helm/aihr/values-prod.yaml
+++ b/helm/aihr/values-prod.yaml
@@ -4,3 +4,9 @@ global:
     host: api.ai-hr.student.k8s.aet.cit.tum.de
     tlsSecret: ai-hr-prod-tls
     corsAllowed: "https://ai-hr.student.k8s.aet.cit.tum.de/api/v1/applications"
+
+frontend:
+  ingress:
+    enabled: true
+    host: ai-hr.student.k8s.aet.cit.tum.de
+    tlsSecret: ai-hr-prod-tls


### PR DESCRIPTION
closes #23 
closes #21 
This pull request introduces changes to support the deployment of the AI HR frontend service using Docker and Helm. Key updates include adjustments to Docker Compose configurations, the addition of Helm charts for Kubernetes deployment, and updates to environment-specific values files.

### Docker Compose Updates:
* Modified `docker-compose.prod.deploy.yml` and `docker-compose.prod.yml` to update the `healthcheck` syntax for better readability and maintainability. [[1]](diffhunk://#diff-a31d9f4c2ed1b277a22c113593c6029b8320312ad7b4e0f26755a58b1b0c34d1L49-R52) [[2]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L52-R55)
* Replaced the commented-out frontend service definition with an active configuration using an image reference (`ghcr.io`) and added labels for Traefik routing. [[1]](diffhunk://#diff-a31d9f4c2ed1b277a22c113593c6029b8320312ad7b4e0f26755a58b1b0c34d1L241-R251) [[2]](diffhunk://#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3L259-R272)

### Helm Chart for Frontend Service:
* Added a new Helm chart (`helm/aihr/charts/frontend`) with configurations for deployment (`deployment.yaml`), service (`service.yaml`), ingress (`ingress.yaml`), and chart metadata (`Chart.yaml`). These files define the Kubernetes resources required for deploying the frontend service. [[1]](diffhunk://#diff-0f61f6bf60a857740b5fc88011b57c7a8a8ed21ac7badbe36f37b7ad8defccfeR1-R5) [[2]](diffhunk://#diff-4e3453fb9b9dd1c02f30f811327bfdb13800d917bb4014e944fef5fbc3ed2438R1-R29) [[3]](diffhunk://#diff-d38b53b1ba7afdbfcf405e5ce819cdd38de9fb9f7351d1a63b8cea3fe0400fcdR1-R27) [[4]](diffhunk://#diff-e93ae59723688aa7facfbd9f2358efe30b19564607bcfbeddc5fb2764cbd07e3R1-R11)
* Created helper templates (`_helpers.tpl`) for generating fully-qualified names for resources.
* Added default values in `values.yaml` for replicas, image settings, service port, and ingress configuration.

### Environment-Specific Values:
* Updated `values-dev.yaml` and `values-prod.yaml` to include frontend-specific ingress configurations, such as host and TLS secret settings, for development and production environments. [[1]](diffhunk://#diff-9d56b35952e98cf16882bed586fef92abd11b218e4e07785398248aca7a5276eR7-R12) [[2]](diffhunk://#diff-499dbf1bdff2b549836241d2812c085911242a155090e0a255f4c3e52e9d866fR7-R12)